### PR TITLE
Fix figlet crash in single file executable

### DIFF
--- a/apps/magus/package.json
+++ b/apps/magus/package.json
@@ -22,6 +22,7 @@
     "@magus/server": "workspace:*",
     "@magus/tools": "workspace:*",
     "ai": "catalog:",
+    "figlet": "catalog:ui",
     "eventsource": "^4.0.0",
     "fuse.js": "^7.1.0",
     "hono": "catalog:",

--- a/apps/magus/src/components/Banner.tsx
+++ b/apps/magus/src/components/Banner.tsx
@@ -1,4 +1,5 @@
 import { FigletText } from "@magus/react";
+import stronger from "figlet/fonts/Stronger Than All";
 import { Box, Text } from "ink";
 import Gradient from "ink-gradient";
 import { useRoutes } from "../contexts";
@@ -8,7 +9,9 @@ export const Banner = () => {
   return (
     <Box flexDirection="column" alignItems="center" justifyContent="center">
       <Gradient name="retro">
-        <FigletText font="Stronger Than All">MAGUS</FigletText>
+        <FigletText font="Stronger Than All" fontData={stronger}>
+          MAGUS
+        </FigletText>
       </Gradient>
       <Text></Text>
       <Text>Press Enter to start chat</Text>

--- a/bun.lock
+++ b/bun.lock
@@ -33,6 +33,7 @@
         "@magus/tools": "workspace:*",
         "ai": "catalog:",
         "eventsource": "^4.0.0",
+        "figlet": "catalog:ui",
         "fuse.js": "^7.1.0",
         "hono": "catalog:",
         "ink": "catalog:ui",
@@ -134,14 +135,13 @@
       "name": "@magus/react",
       "dependencies": {
         "cli-highlight": "^2.1.11",
-        "figlet": "^1.7.0",
+        "figlet": "catalog:ui",
         "marked": "^16.2.1",
         "marked-terminal": "^7.3.0",
       },
       "devDependencies": {
         "@types/bun": "catalog:ts",
         "@types/cardinal": "^2.1.1",
-        "@types/figlet": "^1.5.8",
         "@types/marked-terminal": "^6.1.1",
         "ink-testing-library": "catalog:test",
       },
@@ -219,6 +219,7 @@
       "typescript": "^5.9.2",
     },
     "ui": {
+      "figlet": "^1.9.3",
       "ink": "^6.2.0",
       "ink-gradient": "^3.0.0",
       "ink-text-input": "^6.0.0",
@@ -347,8 +348,6 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/figlet": ["@types/figlet@1.7.0", "", {}, "sha512-KwrT7p/8Eo3Op/HBSIwGXOsTZKYiM9NpWRBJ5sVjWP/SmlS+oxxRvJht/FNAtliJvja44N3ul1yATgohnVBV0Q=="],
-
     "@types/gradient-string": ["@types/gradient-string@1.1.6", "", { "dependencies": { "@types/tinycolor2": "*" } }, "sha512-LkaYxluY4G5wR1M4AKQUal2q61Di1yVVCw42ImFTuaIoQVgmV0WP1xUaLB8zwb47mp82vWTpePI9JmrjEnJ7nQ=="],
 
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
@@ -476,6 +475,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@14.0.1", "", {}, "sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -613,7 +614,7 @@
 
     "fastq": ["fastq@1.19.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ=="],
 
-    "figlet": ["figlet@1.8.2", "", { "bin": { "figlet": "bin/index.js" } }, "sha512-iPCpE9B/rOcjewIzDnagP9F2eySzGeHReX8WlrZQJkqFBk2wvq8gY0c6U6Hd2y9HnX1LQcYSeP7aEHoPt6sVKQ=="],
+    "figlet": ["figlet@1.9.3", "", { "dependencies": { "commander": "^14.0.0" }, "bin": { "figlet": "bin/index.js" } }, "sha512-majPgOpVtrZN1iyNGbsUP6bOtZ6eaJgg5HHh0vFvm5DJhh8dc+FJpOC4GABvMZ/A7XHAJUuJujhgUY/2jPWgMA=="],
 
     "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     },
     "catalogs": {
       "ui": {
+        "figlet": "^1.9.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.8.1",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -10,13 +10,12 @@
   "devDependencies": {
     "@types/bun": "catalog:ts",
     "@types/cardinal": "^2.1.1",
-    "@types/figlet": "^1.5.8",
     "@types/marked-terminal": "^6.1.1",
     "ink-testing-library": "catalog:test"
   },
   "dependencies": {
     "cli-highlight": "^2.1.11",
-    "figlet": "^1.7.0",
+    "figlet": "catalog:ui",
     "marked": "^16.2.1",
     "marked-terminal": "^7.3.0"
   },

--- a/packages/react/src/components/FigletText.tsx
+++ b/packages/react/src/components/FigletText.tsx
@@ -1,10 +1,19 @@
 import figlet, { type FigletOptions } from "figlet";
 import { Text } from "ink";
+import { useEffect, useState } from "react";
 
 export type FigletTextProps = FigletOptions & { fontData?: string; children: string };
 
 export const FigletText = ({ children, fontData, ...options }: FigletTextProps) => {
-  if (options.font && fontData) figlet.parseFont(options.font, fontData);
-  const result = figlet.textSync(children, options);
-  return <Text>{result}</Text>;
+  const [text, setText] = useState<string>("");
+
+  useEffect(() => {
+    if (options.font && fontData) {
+      figlet.parseFont(options.font, fontData);
+    }
+
+    setText(figlet.textSync(children, options));
+  }, [children, fontData, options]);
+
+  return <Text>{text}</Text>;
 };

--- a/packages/react/src/components/FigletText.tsx
+++ b/packages/react/src/components/FigletText.tsx
@@ -1,27 +1,10 @@
 import figlet, { type FigletOptions } from "figlet";
 import { Text } from "ink";
-import { useEffect, useState } from "react";
 
 export type FigletTextProps = FigletOptions & { fontData?: string; children: string };
 
 export const FigletText = ({ children, fontData, ...options }: FigletTextProps) => {
-  const [text, setText] = useState(children);
-  useEffect(() => {
-    let disposed = false;
-    if (options.font && fontData) figlet.parseFont(options.font, fontData);
-    figlet
-      .text(children, options)
-      .then((text) => {
-        if (disposed) return;
-        setText(text);
-      })
-      .catch(() => {
-        // no-op
-      });
-    return () => {
-      disposed = true;
-    };
-  }, [children, fontData, options]);
-
-  return <Text>{text}</Text>;
+  if (options.font && fontData) figlet.parseFont(options.font, fontData);
+  const result = figlet.textSync(children, options);
+  return <Text>{result}</Text>;
 };

--- a/packages/react/src/components/FigletText.tsx
+++ b/packages/react/src/components/FigletText.tsx
@@ -4,16 +4,17 @@ import { useEffect, useState } from "react";
 
 export type FigletTextProps = FigletOptions & { fontData?: string; children: string };
 
-export const FigletText = ({ children, fontData, ...options }: FigletTextProps) => {
+export const FigletText = (props: FigletTextProps) => {
+  const { font, fontData, children } = props;
   const [text, setText] = useState<string>("");
 
   useEffect(() => {
-    if (options.font && fontData) {
-      figlet.parseFont(options.font, fontData);
+    if (font && fontData) {
+      figlet.parseFont(font, fontData);
     }
 
-    setText(figlet.textSync(children, options));
-  }, [children, fontData, options]);
+    setText(figlet.textSync(children, props));
+  }, [children, font, fontData, props]);
 
   return <Text>{text}</Text>;
 };

--- a/packages/react/src/components/FigletText.tsx
+++ b/packages/react/src/components/FigletText.tsx
@@ -1,11 +1,26 @@
-import figlet, { type FigletOptions } from "figlet";
+import figlet, { type FontName } from "figlet";
 import { Text } from "ink";
 import { useEffect, useState } from "react";
 
-export type FigletTextProps = FigletOptions & { fontData?: string; children: string };
+export type FigletTextProps = {
+  fontData?: string;
+  children: string;
+  font?: FontName;
+  width?: number;
+  whitespaceBreak?: boolean;
+  printDirection?: -1 | 0 | 1;
+  showHardBlanks?: boolean;
+};
 
-export const FigletText = (props: FigletTextProps) => {
-  const { font, fontData, children } = props;
+export const FigletText = ({
+  children,
+  fontData,
+  font,
+  width,
+  whitespaceBreak,
+  printDirection,
+  showHardBlanks,
+}: FigletTextProps) => {
   const [text, setText] = useState<string>("");
 
   useEffect(() => {
@@ -13,8 +28,16 @@ export const FigletText = (props: FigletTextProps) => {
       figlet.parseFont(font, fontData);
     }
 
-    setText(figlet.textSync(children, props));
-  }, [children, font, fontData, props]);
+    setText(
+      figlet.textSync(children, {
+        font,
+        width,
+        whitespaceBreak,
+        printDirection,
+        showHardBlanks,
+      }),
+    );
+  }, [children, font, fontData, width, whitespaceBreak, printDirection, showHardBlanks]);
 
   return <Text>{text}</Text>;
 };

--- a/packages/react/src/components/FigletText.tsx
+++ b/packages/react/src/components/FigletText.tsx
@@ -1,13 +1,27 @@
-import type { Options } from "figlet";
-import figlet from "figlet";
+import figlet, { type FigletOptions } from "figlet";
 import { Text } from "ink";
-import { useMemo } from "react";
+import { useEffect, useState } from "react";
 
-export type FigletTextProps = Options & { children: string };
+export type FigletTextProps = FigletOptions & { fontData?: string; children: string };
 
-export const FigletText = (props: FigletTextProps) => {
-  const { children, ...options } = props;
-  const renderedText = useMemo(() => figlet.textSync(children, options), [children, options]);
+export const FigletText = ({ children, fontData, ...options }: FigletTextProps) => {
+  const [text, setText] = useState(children);
+  useEffect(() => {
+    let disposed = false;
+    if (options.font && fontData) figlet.parseFont(options.font, fontData);
+    figlet
+      .text(children, options)
+      .then((text) => {
+        if (disposed) return;
+        setText(text);
+      })
+      .catch(() => {
+        // no-op
+      });
+    return () => {
+      disposed = true;
+    };
+  }, [children, fontData, options]);
 
-  return <Text>{renderedText}</Text>;
+  return <Text>{text}</Text>;
 };


### PR DESCRIPTION
When using bundled version of the code, it would crash in the figlet banner from files not being part of the bundle.

This imports the used font so it ends up part of the single file executable.